### PR TITLE
Disable branch protection on release/* branch

### DIFF
--- a/otterdog/eclipse-set.jsonnet
+++ b/otterdog/eclipse-set.jsonnet
@@ -36,8 +36,7 @@ orgs.newOrg('technology.set', 'eclipse-set') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        custom_branch_protection_rule('main'),
-        custom_branch_protection_rule('release/*'),
+        custom_branch_protection_rule('main')
       ],
     },
     orgs.newRepo('build') {
@@ -61,8 +60,7 @@ orgs.newOrg('technology.set', 'eclipse-set') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        custom_branch_protection_rule('main'),
-        custom_branch_protection_rule('release/*'),
+        custom_branch_protection_rule('main')
       ],
     },
     orgs.newRepo('set') {
@@ -73,8 +71,7 @@ orgs.newOrg('technology.set', 'eclipse-set') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        custom_branch_protection_rule('main'),
-        custom_branch_protection_rule('release/*'),
+        custom_branch_protection_rule('main')
       ],
     },
     orgs.newRepo('toolboxmodel') {
@@ -86,8 +83,7 @@ orgs.newOrg('technology.set', 'eclipse-set') {
         actions_can_approve_pull_request_reviews: false,
       },
       branch_protection_rules: [
-        custom_branch_protection_rule('main'),
-        custom_branch_protection_rule('release/*'),
+        custom_branch_protection_rule('main')
       ],      
     },
   ],


### PR DESCRIPTION
I made a mistake when creating a new branch for the SET release 2.4. The release branch should have been created by the eclipse-bot, but I did it manually. As a result, commits on this branch cannot be pushed to GitHub without a pull request. I will delete the branch and create a revert PR.